### PR TITLE
add bitstring extension

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
@@ -124,6 +124,10 @@ exts_list = [
         'modulename': 'enum',
         'source_urls': ['https://pypi.python.org/packages/source/e/enum34'],
     }),
+    ('bitstring', '3.1.3', {
+        'source_tmpl': '%(name)s-%(version)s.zip',
+        'source_urls': ['https://pypi.python.org/packages/source/b/bitstring'],
+    }),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/2423, to keep this easyconfig in sync with existing Python easyconfigs (cfr. #2471)
