### PR TITLE
use flex easyblock

### DIFF
--- a/easybuild/easyconfigs/f/flex/flex-2.6.0-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/f/flex/flex-2.6.0-GCC-4.9.2.eb
@@ -1,5 +1,3 @@
-easyblock = 'ConfigureMake'
-
 name = 'flex'
 version = '2.6.0'
 


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/2485

There's an easyblock available for flex, so we should use it.

See also https://github.com/hpcugent/easybuild-easyconfigs/pull/2486
