### PR TITLE
sync Python easyconfigs with foss/2015a with equivalent ones in develop

### DIFF
--- a/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-2.7.11-foss-2015a.eb
@@ -23,14 +23,14 @@ dependencies = [
     ('SQLite', '3.10.0'),
     ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),  # required for pycrypto
-#   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
-#   nice to have an up to date openssl for security reasons
+    #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
+    #   nice to have an up to date openssl for security reasons
 ]
 
 osdependencies = [('openssl-devel', 'libssl-dev', 'libopenssl-devel')]
 
 # order is important!
-# package versions updated 28 May 2015
+# package versions updated May 28th 2015
 exts_list = [
     ('setuptools', '18.7.1', {
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],

--- a/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/Python/Python-3.5.1-foss-2015a.eb
@@ -20,8 +20,9 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('SQLite', '3.10.0'),
-    ('Tk', '8.6.4', '-no-X11'),
+    ('Tk', '8.6.4', '-no-X11'),  # this requires a full X11 stack
     ('GMP', '6.1.0'),
+    ('XZ', '5.2.2'),
 #   ('OpenSSL', '1.0.1q'),  # OS dependency should be preferred if the os version is more recent then this version, it's
 #   nice to have an up to date openssl for security reasons
 ]
@@ -29,7 +30,7 @@ dependencies = [
 osdependencies = [('openssl-devel', 'libssl-dev')]
 
 # order is important!
-# package versions updated 10 Jan 2017 cf. EasyConfig for Python-3.5.1-foss-2016a.eb
+# package versions updated Feb 25th 2016
 exts_list = [
     ('setuptools', '20.1.1', {
         'source_urls': ['https://pypi.python.org/packages/source/s/setuptools/'],


### PR DESCRIPTION
@valtandor for https://github.com/hpcugent/easybuild-easyconfigs/pull/2834, to avoid making needless (imho) changes to existing easyconfigs, and to stay in sync with easyconfigs that are already there (w/ a different toolchain)